### PR TITLE
Add keycloak's JWT validator service and bean

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     compile('commons-io:commons-io:2.6')
     compile('org.bitbucket.b_c:jose4j:0.6.4')
     compile('net.bytebuddy:byte-buddy:1.8.22')
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.11.1'
 
     testCompile('junit:junit:4.12')
     testCompile('org.spockframework:spock-core:1.1-groovy-2.4')

--- a/src/main/java/br/com/quintoandar/javajwt/QuintoAndarKeycloakJwt.java
+++ b/src/main/java/br/com/quintoandar/javajwt/QuintoAndarKeycloakJwt.java
@@ -1,0 +1,12 @@
+package br.com.quintoandar.javajwt;
+
+import org.jose4j.jwt.consumer.InvalidJwtException;
+
+import java.util.Map;
+import java.util.Optional;
+
+public interface QuintoAndarKeycloakJwt {
+
+    Optional<Map<String, Object>> getPayload(String jwt) throws InvalidJwtException;
+
+}

--- a/src/main/java/br/com/quintoandar/javajwt/QuintoAndarKeycloakJwtBean.java
+++ b/src/main/java/br/com/quintoandar/javajwt/QuintoAndarKeycloakJwtBean.java
@@ -33,7 +33,7 @@ public class QuintoAndarKeycloakJwtBean implements QuintoAndarKeycloakJwt {
         this.quintoAndarKeycloakPublicKeyService = quintoAndarKeycloakPublicKeyService;
     }
 
-    @Autowired
+    @Override
     public Optional<Map<String, Object>> getPayload(final String jwt) throws InvalidJwtException {
         if (jwt == null) {
             return Optional.empty();

--- a/src/main/java/br/com/quintoandar/javajwt/QuintoAndarKeycloakJwtBean.java
+++ b/src/main/java/br/com/quintoandar/javajwt/QuintoAndarKeycloakJwtBean.java
@@ -18,7 +18,7 @@ import java.util.Base64;
 import java.util.Map;
 import java.util.Optional;
 
-public class QuintoAndarKeycloakJwtBean implements QuintoAndarJwt {
+public class QuintoAndarKeycloakJwtBean implements QuintoAndarKeycloakJwt {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(QuintoAndarKeycloakJwtBean.class);
 

--- a/src/main/java/br/com/quintoandar/javajwt/QuintoAndarKeycloakJwtBean.java
+++ b/src/main/java/br/com/quintoandar/javajwt/QuintoAndarKeycloakJwtBean.java
@@ -1,0 +1,89 @@
+package br.com.quintoandar.javajwt;
+
+import org.jose4j.jwk.RsaJsonWebKey;
+import org.jose4j.jwt.consumer.InvalidJwtException;
+import org.jose4j.jwt.consumer.JwtConsumer;
+import org.jose4j.jwt.consumer.JwtConsumerBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.io.IOException;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.interfaces.RSAPublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.X509EncodedKeySpec;
+import java.util.Base64;
+import java.util.Map;
+import java.util.Optional;
+
+public class QuintoAndarKeycloakJwtBean implements QuintoAndarJwt {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(QuintoAndarKeycloakJwtBean.class);
+
+    private static final String KEY_ALGORITHM = "RSA";
+
+    private QuintoAndarKeycloakPublicKeyService quintoAndarKeycloakPublicKeyService;
+
+    private JwtConsumer jwtConsumer;
+
+    @Autowired
+    public QuintoAndarKeycloakJwtBean(final QuintoAndarKeycloakPublicKeyService quintoAndarKeycloakPublicKeyService) {
+        this.quintoAndarKeycloakPublicKeyService = quintoAndarKeycloakPublicKeyService;
+    }
+
+    @Autowired
+    public Optional<Map<String, Object>> getPayload(final String jwt) throws InvalidJwtException {
+        if (jwt == null) {
+            return Optional.empty();
+        }
+
+        if (!isReady()) {
+            try {
+                setup();
+            } catch (SetupException e) {
+                LOGGER.error("Failed to setup QuintoAndarKeycloakJwtBean", e);
+                return Optional.empty();
+            }
+        }
+
+        final Map<String, Object> payload = jwtConsumer.processToClaims(jwt).getClaimsMap();
+        return Optional.ofNullable(payload);
+    }
+
+    private void setup() throws SetupException {
+        try {
+            LOGGER.info("Setting up QuintoAndarKeycloakJwtBean");
+            final KeyFactory keyFactory = KeyFactory.getInstance(KEY_ALGORITHM);
+            final X509EncodedKeySpec keySpec = getPublicKeySpec();
+            final RSAPublicKey publicKey = (RSAPublicKey) keyFactory.generatePublic(keySpec);
+            final RsaJsonWebKey webKey = new RsaJsonWebKey(publicKey);
+            jwtConsumer = new JwtConsumerBuilder().setVerificationKey(webKey.getKey()).build();
+        } catch (NoSuchAlgorithmException | IOException | InvalidKeySpecException e) {
+            throw new SetupException(e);
+        }
+    }
+
+    private boolean isReady() {
+        return jwtConsumer != null;
+    }
+
+    private X509EncodedKeySpec getPublicKeySpec() throws IOException {
+        final String encodedKey = strippedKey(quintoAndarKeycloakPublicKeyService.fetchKeycloakPublicKey());
+
+        final byte[] decodedKey = Base64.getDecoder().decode(encodedKey);
+
+        return new X509EncodedKeySpec(decodedKey);
+    }
+
+    private String strippedKey(final String publicKey) {
+        return publicKey.replaceAll("\\n", "");
+    }
+
+    // visible for testing
+    protected void setQuintoAndarKeycloakPublicKeyService(final QuintoAndarKeycloakPublicKeyService quintoAndarKeycloakPublicKeyService) {
+        this.quintoAndarKeycloakPublicKeyService = quintoAndarKeycloakPublicKeyService;
+    }
+
+}

--- a/src/main/java/br/com/quintoandar/javajwt/QuintoAndarKeycloakJwtBean.java
+++ b/src/main/java/br/com/quintoandar/javajwt/QuintoAndarKeycloakJwtBean.java
@@ -59,7 +59,7 @@ public class QuintoAndarKeycloakJwtBean implements QuintoAndarKeycloakJwt {
             final X509EncodedKeySpec keySpec = getPublicKeySpec();
             final RSAPublicKey publicKey = (RSAPublicKey) keyFactory.generatePublic(keySpec);
             final RsaJsonWebKey webKey = new RsaJsonWebKey(publicKey);
-            jwtConsumer = new JwtConsumerBuilder().setVerificationKey(webKey.getKey()).build();
+            jwtConsumer = new JwtConsumerBuilder().setRequireExpirationTime().setVerificationKey(webKey.getKey()).build();
         } catch (NoSuchAlgorithmException | IOException | InvalidKeySpecException e) {
             throw new SetupException(e);
         }

--- a/src/main/java/br/com/quintoandar/javajwt/QuintoAndarKeycloakPublicKeyService.java
+++ b/src/main/java/br/com/quintoandar/javajwt/QuintoAndarKeycloakPublicKeyService.java
@@ -1,0 +1,49 @@
+package br.com.quintoandar.javajwt;
+
+import br.com.quintoandar.javajwt.config.QuintoandarProperties;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.io.IOUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.net.URLConnection;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+public class QuintoAndarKeycloakPublicKeyService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(QuintoAndarKeycloakPublicKeyService.class);
+
+    private static final int BUFFER_SIZE = 8192;
+
+    private final QuintoandarProperties quintoandarProperties;
+
+    @Autowired
+    public QuintoAndarKeycloakPublicKeyService(final QuintoandarProperties quintoandarProperties) {
+        this.quintoandarProperties = quintoandarProperties;
+    }
+
+    // visible for testing
+    protected String fetchKeycloakPublicKey() throws IOException {
+        final String JWT_KEYCLOAK_PATH = quintoandarProperties.getKeycloakUrl();
+
+        LOGGER.info("Opening connection to {}", JWT_KEYCLOAK_PATH);
+        final URL url = new URL(JWT_KEYCLOAK_PATH);
+        final URLConnection connection = url.openConnection();
+        connection.connect();
+
+        LOGGER.info("Connection opened, fetching public key");
+        final InputStream stream = new BufferedInputStream(url.openStream(), BUFFER_SIZE);
+
+        // Keycloak's realm info endpoint returns a payload with a public_key property
+        final ObjectMapper om = new ObjectMapper();
+        final Map<String, Object> keycloakRealmInfo = om.readValue(stream, Map.class);
+
+        return (String) keycloakRealmInfo.get("public_key");
+    }
+}

--- a/src/main/java/br/com/quintoandar/javajwt/QuintoAndarKeycloakPublicKeyService.java
+++ b/src/main/java/br/com/quintoandar/javajwt/QuintoAndarKeycloakPublicKeyService.java
@@ -28,7 +28,6 @@ public class QuintoAndarKeycloakPublicKeyService {
         this.quintoandarProperties = quintoandarProperties;
     }
 
-    // visible for testing
     protected String fetchKeycloakPublicKey() throws IOException {
         final String JWT_KEYCLOAK_PATH = quintoandarProperties.getKeycloakUrl();
 

--- a/src/main/java/br/com/quintoandar/javajwt/QuintoandarJwtConfiguration.java
+++ b/src/main/java/br/com/quintoandar/javajwt/QuintoandarJwtConfiguration.java
@@ -21,7 +21,7 @@ public class QuintoandarJwtConfiguration {
     }
 
     @Bean
-    public QuintoAndarJwt quintoAndarKeycloakJwt() {
+    public QuintoAndarKeycloakJwt quintoAndarKeycloakJwt() {
         return new QuintoAndarKeycloakJwtBean(quintoAndarKeycloakPublicKeyService());
     }
 

--- a/src/main/java/br/com/quintoandar/javajwt/QuintoandarJwtConfiguration.java
+++ b/src/main/java/br/com/quintoandar/javajwt/QuintoandarJwtConfiguration.java
@@ -21,8 +21,18 @@ public class QuintoandarJwtConfiguration {
     }
 
     @Bean
+    public QuintoAndarJwt quintoAndarKeycloakJwt() {
+        return new QuintoAndarKeycloakJwtBean(quintoAndarKeycloakPublicKeyService());
+    }
+
+    @Bean
     public QuintoAndarPublicKeyService quintoAndarPublicKeyService() {
         return new QuintoAndarPublicKeyService(quintoandarProperties);
+    }
+
+    @Bean
+    public QuintoAndarKeycloakPublicKeyService quintoAndarKeycloakPublicKeyService() {
+        return new QuintoAndarKeycloakPublicKeyService(quintoandarProperties);
     }
 
 }

--- a/src/main/java/br/com/quintoandar/javajwt/config/QuintoandarProperties.java
+++ b/src/main/java/br/com/quintoandar/javajwt/config/QuintoandarProperties.java
@@ -9,7 +9,14 @@ public class QuintoandarProperties {
     @Value("${main.url}")
     private String mainUrl;
 
+    @Value("${keycloak.url}")
+    private String keycloakUrl;
+
     public String getMainUrl() {
         return mainUrl;
+    }
+
+    public String getKeycloakUrl() {
+        return keycloakUrl;
     }
 }

--- a/src/test/groovy/br/com/quintoandar/javajwt/QuintoAndarKeycloakJwtSpec.groovy
+++ b/src/test/groovy/br/com/quintoandar/javajwt/QuintoAndarKeycloakJwtSpec.groovy
@@ -4,24 +4,22 @@ import org.jose4j.jwt.consumer.InvalidJwtException
 import spock.lang.Shared
 import spock.lang.Specification
 
-class QuintoAndarJwtSpec extends Specification {
+class QuintoAndarKeycloakJwtSpec extends Specification {
 
   @Shared
-  def publicKeyServiceMock = Mock(QuintoAndarPublicKeyService)
+  def keycloakPublicKeyServiceMock = Mock(QuintoAndarKeycloakPublicKeyService)
 
   @Shared
-  def subject = GroovySpy(QuintoAndarJwtBean)
+  def keycloakSubject = GroovySpy(QuintoAndarKeycloakJwtBean)
 
   @Shared
-  def fakePublicKey2048bit = "-----BEGIN PUBLIC KEY-----\n" +
-      "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA6A+CGRKw/xpaAqy/1eJl\n" +
-      "f5urRzmUWhgGVNedUhmgMudMBQIXPYVOWQQydWq/e+SaxdT7fRQE/Ae0eOCPgwty\n" +
-      "FmLoA/ugGT0AGF5juXBzCwXY9iLdIejQPDbbVVMICFteRCDkLaLZy4U3qj895TzZ\n" +
-      "Hg7gXwo4l3oi4EUT6MchMANGw4D4/SIZcdzm9R/pV9+AHYaA1k8YP612YXFe4W39\n" +
-      "ZPXuQrz/Lnys7MgPo/NSpKmxMp82el/vVW9wlQKA4fY/zz7GgfsUf25hVpnCC8V6\n" +
-      "b1kIU+5TfYSjTThHfSqI8aDIXohIiQu3KISNXqJV4Tx+PMqeQkKT0GIaqKM+b4jP\n" +
-      "WQIDAQAB\n" +
-      "-----END PUBLIC KEY-----"
+  def fakePublicKey2048bit = "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AM\n" +
+      "IIBCgKCAQEA6A+CGRKw/xpaAqy/1eJlf5urRzmUWhgGVNedUhmgMudMBQIXPYVOW\n" +
+      "QQydWq/e+SaxdT7fRQE/Ae0eOCPgwtyFmLoA/ugGT0AGF5juXBzCwXY9iLdIejQP\n" +
+      "DbbVVMICFteRCDkLaLZy4U3qj895TzZHg7gXwo4l3oi4EUT6MchMANGw4D4/SIZc\n" +
+      "dzm9R/pV9+AHYaA1k8YP612YXFe4W39ZPXuQrz/Lnys7MgPo/NSpKmxMp82el/vV\n" +
+      "W9wlQKA4fY/zz7GgfsUf25hVpnCC8V6b1kIU+5TfYSjTThHfSqI8aDIXohIiQu3K\n" +
+      "ISNXqJV4Tx+PMqeQkKT0GIaqKM+b4jPWQIDAQAB"
 
   @Shared
   def fakePrivateKey2048bit = "-----BEGIN PRIVATE KEY-----\n" +
@@ -71,13 +69,13 @@ class QuintoAndarJwtSpec extends Specification {
   def fakeJwt = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6NywibmFtZSI6IkphbWVzIEJvbmQiLCJlbWFpbCI6ImphbWVzLmJvbmRAcXVpbnRvYW5kYXIuY29tLmJyIiwicm9sZSI6ImFkbWluIn0.piI9eOSM06yfh9Lzy8O0iUW18mIGql7vSIEjWYrm6pbZCQNV-7LxU12PXO2ZdH-zqbv7VVtkJvuO3pseACKYzsukXbswb9Rc_v77UaqMj4QGXHTJfoniL0mFAMxcqJcJVgmS2mE03gKh62y_BA8Emh2Gbal-44grYPn2HOG7nNjGa799SKtvqSG2beilEnXXURidH5QNA7kWXIkLfVbRgMjTmu8axQUHa98dP95Hopnn2-6CJGtpPyZUqT9df76_r8B2oMY4N6pJJWo-ik8y7DAV8WyJVsLQTj_1rzHLGxtMT7aXEEtAufGovgBc7qV1Vgu4VhsoIpqQEqnby5m7jQ"
 
   def setupSpec() {
-    publicKeyServiceMock.fetchMainPublicKey() >> fakePublicKey2048bit
-    subject.quintoAndarPublicKeyService = publicKeyServiceMock
+    keycloakPublicKeyServiceMock.fetchKeycloakPublicKey() >> fakePublicKey2048bit
+    keycloakSubject.quintoAndarKeycloakPublicKeyService = keycloakPublicKeyServiceMock
   }
 
-  def "get payload from valid Main jwt"() {
+  def "get payload from valid Keycloak jwt"() {
     when:
-    def result = subject.getPayload(fakeJwt)
+    def result = keycloakSubject.getPayload(fakeJwt)
 
     then:
     result.isPresent()
@@ -90,7 +88,7 @@ class QuintoAndarJwtSpec extends Specification {
     claims.get("role") == "admin"
   }
 
-  def "get payload from invalid Main jwt throws exception"() {
+  def "get payload from invalid Keycloak jwt throws exception"() {
     given:
     def jwtForOtherKeys = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6NywibmFtZSI6IkphbWVzIEJvbmQiLCJlbWFpbCI6Imphb" +
         "WVzLmJvbmRAcXVpbnRvYW5kYXIuY29tLmJyIiwicm9sZSI6ImFkbWluIn0.fwuOMtnmdKV7QeesDPWIsK-5Ipanv9PHPenzUWg5EOXG639z9" +
@@ -99,7 +97,7 @@ class QuintoAndarJwtSpec extends Specification {
         "1ypOaXe8A5VVr1YDRpxlcBHvbxymCR0uJmeq2HCuAPyoN97KQHLrw5ehJ5TyLKTCDTm1aSjnl1O0g"
 
     when:
-    def result = subject.getPayload(jwtForOtherKeys)
+    def result = keycloakSubject.getPayload(jwtForOtherKeys)
 
     then:
     thrown(InvalidJwtException)

--- a/src/test/groovy/br/com/quintoandar/javajwt/QuintoAndarKeycloakJwtSpec.groovy
+++ b/src/test/groovy/br/com/quintoandar/javajwt/QuintoAndarKeycloakJwtSpec.groovy
@@ -14,41 +14,40 @@ class QuintoAndarKeycloakJwtSpec extends Specification {
 
   @Shared
   def fakePublicKey2048bit = "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AM\n" +
-      "IIBCgKCAQEA6A+CGRKw/xpaAqy/1eJlf5urRzmUWhgGVNedUhmgMudMBQIXPYVOW\n" +
-      "QQydWq/e+SaxdT7fRQE/Ae0eOCPgwtyFmLoA/ugGT0AGF5juXBzCwXY9iLdIejQP\n" +
-      "DbbVVMICFteRCDkLaLZy4U3qj895TzZHg7gXwo4l3oi4EUT6MchMANGw4D4/SIZc\n" +
-      "dzm9R/pV9+AHYaA1k8YP612YXFe4W39ZPXuQrz/Lnys7MgPo/NSpKmxMp82el/vV\n" +
-      "W9wlQKA4fY/zz7GgfsUf25hVpnCC8V6b1kIU+5TfYSjTThHfSqI8aDIXohIiQu3K\n" +
-      "ISNXqJV4Tx+PMqeQkKT0GIaqKM+b4jPWQIDAQAB"
+      "IIBCgKCAQEAnzyis1ZjfNB0bBgKFMSvvkTtwlvBsaJq7S5wA+kzeVOVpVWwkWdVh\n" +
+      "a4s38XM/pa/yr47av7+z3VTmvDRyAHcaT92whREFpLv9cj5lTeJSibyr/Mrm/Ytj\n" +
+      "CZVWgaOYIhwrXwKLqPr/11inWsAkfIytvHWTxZYEcXLgAXFuUuaS3uF9gEiNQwzG\n" +
+      "TU1v0FqkqTBr4B8nW3HCN47XUu0t8Y0e+lf4s4OxQawWD79J9/5d3Ry0vbV3Am1F\n" +
+      "tGJiJvOwRsIfVChDpYStTcHTCMqtvWbV6L11BWkpzGXSW4Hv43qa+GSYOD2QU68M\n" +
+      "b59oSk2OB+BtOLpJofmbGEGgvmwyCI9MwIDAQAB"
 
   @Shared
   def fakePrivateKey2048bit = "-----BEGIN PRIVATE KEY-----\n" +
-      "MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDoD4IZErD/GloC\n" +
-      "rL/V4mV/m6tHOZRaGAZU151SGaAy50wFAhc9hU5ZBDJ1ar975JrF1Pt9FAT8B7R4\n" +
-      "4I+DC3IWYugD+6AZPQAYXmO5cHMLBdj2It0h6NA8NttVUwgIW15EIOQtotnLhTeq\n" +
-      "Pz3lPNkeDuBfCjiXeiLgRRPoxyEwA0bDgPj9Ihlx3Ob1H+lX34AdhoDWTxg/rXZh\n" +
-      "cV7hbf1k9e5CvP8ufKzsyA+j81KkqbEynzZ6X+9Vb3CVAoDh9j/PPsaB+xR/bmFW\n" +
-      "mcILxXpvWQhT7lN9hKNNOEd9KojxoMheiEiJC7cohI1eolXhPH48yp5CQpPQYhqo\n" +
-      "oz5viM9ZAgMBAAECggEBAMteW+tRQCAwndVeQzhUEhNE/1OKGILkLxhHZS3AG27A\n" +
-      "2RRCgs99de35CadxB6Kx8xmQz10MIFom/ng4hEyZyT/pKd/jsqirltvETK0E6S0t\n" +
-      "0LfUUesXtvYuNQWPoKiCOhiGorGD2E7Nzry6c6nkK3p2GxfvQy0s8keNAier61/A\n" +
-      "tAuY+vCQUdCV8v3KFy6edKSj7T0e94kNNYi+lTPLq28f0LfhjFT0DhfWI49wh1Vq\n" +
-      "Tn61bAX0wI0pyc5OIdMMoLQ37aez9iwHCRvYFCuYpaHleNaQ3FpxLaoPrSCQxGyT\n" +
-      "R1MQq51Bbh+MJI7DXO8TJw5ZVoX86tCStR0XdqcGnCkCgYEA9/rO8u2cCNYAxRPk\n" +
-      "n3VHZpmYq9Gvrbq+TbfJxgODCS9kJYAgwN1aeSzhO4nustrHT/B4jLSlR82Qi66Z\n" +
-      "+oaVXWygk5XVdLPMmO2rabDWsQWSWxBli1ez8DAflM+CFm9y1hKxMJiPbC8alZea\n" +
-      "fheiLjOMKElf94mBfobkeUEEmOMCgYEA75Dk/GY2Xel67f08g7X6cI+z4QMtedWd\n" +
-      "5BL63AujBEdZNobazhSDQmoiKqoBhwGertiskNmYpJ21uzA0FrSaO6AUx/5jTgNc\n" +
-      "TCwg2J6gXl+XOKJZ4xTu4ALImFyG4SZ5/QBKBrLs+dacOAnj7WvWvnaWph0rhzR/\n" +
-      "ZdWBUHO295MCgYBEJ26RXbSwyQBVKe5/1N/W1wga0PqTqOt8uLJ/9Z8h+yBvHhPi\n" +
-      "bfPbsfYFQxeTmIWG9vRq14tFfL3pZgdzz2Fl1+EaLugHtxLYRRoDZlLbPEjJNmxy\n" +
-      "K5yMuu0zHQUH3YGWTHTegk+I0DliO9R+K0irogc3W1NA2U351GEe4ju9OQKBgQC6\n" +
-      "27ugG2GgkrKt2u5OlazIC250vfPEqhhDg4JkDDeU6MnvO/SC9YEEVqBbwsr6MQtC\n" +
-      "ugKv4OmszM6pOQoIA8qhY1WSQRvYB8sAJxNfoyrXMZxUMl4GP5eq5sDsBo+2IjrY\n" +
-      "WldjLkClBv5Gv4Am+gw/92O+IdaH2Szdk1EQHZHDPQKBgGx3aAvS68WwA1smzI0Y\n" +
-      "i9zSBlBtqWX3ISAD20c/Oy5jK7YJEn307KqOXYpSNj6D544MffaZvMPafc/6zXmc\n" +
-      "OhyX9yMqdsl3SpJ8HsCD70eBIbS3kIttPb0rMXP/hyX/v/DL3GW0jr4vH9ThkYKQ\n" +
-      "Q23FiefzA2cYDohWY25jrl4f\n" +
+      "MIIEogIBAAKCAQEAnzyis1ZjfNB0bBgKFMSvvkTtwlvBsaJq7S5wA+kzeVOVpVWw\n" +
+      "kWdVha4s38XM/pa/yr47av7+z3VTmvDRyAHcaT92whREFpLv9cj5lTeJSibyr/Mr\n" +
+      "m/YtjCZVWgaOYIhwrXwKLqPr/11inWsAkfIytvHWTxZYEcXLgAXFuUuaS3uF9gEi\n" +
+      "NQwzGTU1v0FqkqTBr4B8nW3HCN47XUu0t8Y0e+lf4s4OxQawWD79J9/5d3Ry0vbV\n" +
+      "3Am1FtGJiJvOwRsIfVChDpYStTcHTCMqtvWbV6L11BWkpzGXSW4Hv43qa+GSYOD2\n" +
+      "QU68Mb59oSk2OB+BtOLpJofmbGEGgvmwyCI9MwIDAQABAoIBACiARq2wkltjtcjs\n" +
+      "kFvZ7w1JAORHbEufEO1Eu27zOIlqbgyAcAl7q+/1bip4Z/x1IVES84/yTaM8p0go\n" +
+      "amMhvgry/mS8vNi1BN2SAZEnb/7xSxbflb70bX9RHLJqKnp5GZe2jexw+wyXlwaM\n" +
+      "+bclUCrh9e1ltH7IvUrRrQnFJfh+is1fRon9Co9Li0GwoN0x0byrrngU8Ak3Y6D9\n" +
+      "D8GjQA4Elm94ST3izJv8iCOLSDBmzsPsXfcCUZfmTfZ5DbUDMbMxRnSo3nQeoKGC\n" +
+      "0Lj9FkWcfmLcpGlSXTO+Ww1L7EGq+PT3NtRae1FZPwjddQ1/4V905kyQFLamAA5Y\n" +
+      "lSpE2wkCgYEAy1OPLQcZt4NQnQzPz2SBJqQN2P5u3vXl+zNVKP8w4eBv0vWuJJF+\n" +
+      "hkGNnSxXQrTkvDOIUddSKOzHHgSg4nY6K02ecyT0PPm/UZvtRpWrnBjcEVtHEJNp\n" +
+      "bU9pLD5iZ0J9sbzPU/LxPmuAP2Bs8JmTn6aFRspFrP7W0s1Nmk2jsm0CgYEAyH0X\n" +
+      "+jpoqxj4efZfkUrg5GbSEhf+dZglf0tTOA5bVg8IYwtmNk/pniLG/zI7c+GlTc9B\n" +
+      "BwfMr59EzBq/eFMI7+LgXaVUsM/sS4Ry+yeK6SJx/otIMWtDfqxsLD8CPMCRvecC\n" +
+      "2Pip4uSgrl0MOebl9XKp57GoaUWRWRHqwV4Y6h8CgYAZhI4mh4qZtnhKjY4TKDjx\n" +
+      "QYufXSdLAi9v3FxmvchDwOgn4L+PRVdMwDNms2bsL0m5uPn104EzM6w1vzz1zwKz\n" +
+      "5pTpPI0OjgWN13Tq8+PKvm/4Ga2MjgOgPWQkslulO/oMcXbPwWC3hcRdr9tcQtn9\n" +
+      "Imf9n2spL/6EDFId+Hp/7QKBgAqlWdiXsWckdE1Fn91/NGHsc8syKvjjk1onDcw0\n" +
+      "NvVi5vcba9oGdElJX3e9mxqUKMrw7msJJv1MX8LWyMQC5L6YNYHDfbPF1q5L4i8j\n" +
+      "8mRex97UVokJQRRA452V2vCO6S5ETgpnad36de3MUxHgCOX3qL382Qx9/THVmbma\n" +
+      "3YfRAoGAUxL/Eu5yvMK8SAt/dJK6FedngcM3JEFNplmtLYVLWhkIlNRGDwkg3I5K\n" +
+      "y18Ae9n7dHVueyslrb6weq7dTkYDi3iOYRW8HRkIQh06wEdbxt0shTzAJvvCQfrB\n" +
+      "jg/3747WSsf/zBTcHihTRBdAv6OmdhV4/dD5YBfLAkLrd+mX7iE=\n" +
       "-----END PRIVATE KEY-----"
 
   /**
@@ -57,16 +56,17 @@ class QuintoAndarKeycloakJwtSpec extends Specification {
    *   "typ": "JWT"
    * },
    * payload: {
-   *   "id": 7,
-   *   "name": "James Bond",
-   *   "email": "james.bond@quintoandar.com.br",
-   *   "role": "admin"
+   *  "id": "86",
+   *  "name": "Maxwell Smart",
+   *  "email": "maxwell.smart@quintoandar.com.br",
+   *  "role": "admin",
+   *  "exp": 4102455600000
    * }
    *
    * (generated by https://jwt.io/)
    */
   @Shared
-  def fakeJwt = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6NywibmFtZSI6IkphbWVzIEJvbmQiLCJlbWFpbCI6ImphbWVzLmJvbmRAcXVpbnRvYW5kYXIuY29tLmJyIiwicm9sZSI6ImFkbWluIn0.piI9eOSM06yfh9Lzy8O0iUW18mIGql7vSIEjWYrm6pbZCQNV-7LxU12PXO2ZdH-zqbv7VVtkJvuO3pseACKYzsukXbswb9Rc_v77UaqMj4QGXHTJfoniL0mFAMxcqJcJVgmS2mE03gKh62y_BA8Emh2Gbal-44grYPn2HOG7nNjGa799SKtvqSG2beilEnXXURidH5QNA7kWXIkLfVbRgMjTmu8axQUHa98dP95Hopnn2-6CJGtpPyZUqT9df76_r8B2oMY4N6pJJWo-ik8y7DAV8WyJVsLQTj_1rzHLGxtMT7aXEEtAufGovgBc7qV1Vgu4VhsoIpqQEqnby5m7jQ"
+  def fakeJwt = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ODYsIm5hbWUiOiJNYXh3ZWxsIFNtYXJ0IiwiZW1haWwiOiJtYXh3ZWxsLnNtYXJ0QHF1aW50b2FuZGFyLmNvbS5iciIsInJvbGUiOiJhZG1pbiIsImV4cCI6NDEwMjQ1NTYwMDAwMH0.TMNdNzFKjrRqt72tdW5PMti1tee_13787UWkqP_sPsmWXkmtlChFgIzEKiWj0aR9NqcUrVWn0U4jGMpnD45BZ7k7CoRvROR06nrUkvJStptEU_H4dGbQId5oJcGzSz92sEJ7GtNmVfW2uiHK71ipY5jy7CosviHwDKAwEcMTJWJp58rbNBoO-esQb-CRztMvHZ5WSl0gxB6pXmglV95um6GAa_Qfve4lAEocTRci9WowHfVdhvPQDKsl7oMTod6Iz3OpPnPlPPH6XMAFs709juuHy3kCUxEv48rQVypUN-Cpn6a53wW1tq7RDJJnXv5bhvTm3421bMJV7kav7bdCmg"
 
   def setupSpec() {
     keycloakPublicKeyServiceMock.fetchKeycloakPublicKey() >> fakePublicKey2048bit
@@ -82,10 +82,11 @@ class QuintoAndarKeycloakJwtSpec extends Specification {
 
     and:
     def claims = result.get()
-    claims.get("id") == 7
-    claims.get("name") == "James Bond"
-    claims.get("email") == "james.bond@quintoandar.com.br"
+    claims.get("id") == 86
+    claims.get("name") == "Maxwell Smart"
+    claims.get("email") == "maxwell.smart@quintoandar.com.br"
     claims.get("role") == "admin"
+    claims.get("exp") == 4102455600000
   }
 
   def "get payload from invalid Keycloak jwt throws exception"() {


### PR DESCRIPTION
## What

Add Keycloak's JWT as an option for JWT validation. Basically doing the same as the original QuintoAndarJwtBean and QuintoAndarPublicKeyService, but the endpoints used by keycloak to fetch the public key returns a payload like:

```
{
    "realm": "something",
    "public_key": "blablabla",
    "token-service": <open-id-url>,
    "account-service": <account-url>,
    "tokens-not-before": 1234
} 
```